### PR TITLE
Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = pathlib.Path("README.md").read_text()
 
 setuptools.setup(
     name="znjson",
-    version="0.1.0",
+    version="0.1.2",
     author="zincwarecode",
     author_email="zincwarecode@gmail.com",
     description="A Python Package to Encode/Decode some common file formats to json",

--- a/znjson/__init__.py
+++ b/znjson/__init__.py
@@ -5,6 +5,6 @@ from znjson.main import ZnDecoder, ZnEncoder
 
 __all__ = ["ConverterBase", "ZnDecoder", "ZnEncoder", "register", "deregister", "config"]
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"
 
 register()


### PR DESCRIPTION
Due to previous uploads of v0.1.0 and v0.1.1 to PyPi we use v0.1.2 as the new release number.